### PR TITLE
SVG of single-line characters for engraving

### DIFF
--- a/utils/Fonts/VectorLettersForEngraving.svg
+++ b/utils/Fonts/VectorLettersForEngraving.svg
@@ -1,0 +1,1012 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="22in"
+   height="8in"
+   viewBox="0 0 22 8"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2 (dc2aedaf03, 2022-05-15)"
+   sodipodi:docname="VectorLettersForEngraving.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="in"
+     showgrid="false"
+     showguides="true"
+     inkscape:zoom="0.70710678"
+     inkscape:cx="977.92868"
+     inkscape:cy="241.83052"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     inkscape:window-x="2552"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid19018"
+       originx="0"
+       originy="0" />
+    <sodipodi:guide
+       position="0,6"
+       orientation="0,1"
+       id="guide19020"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,134,229)" />
+    <sodipodi:guide
+       position="0,5"
+       orientation="0,1"
+       id="guide19022"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,134,229)" />
+    <sodipodi:guide
+       position="0,5.9375"
+       orientation="0,1"
+       id="guide19026"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,134,229)" />
+    <sodipodi:guide
+       position="0,5.0625"
+       orientation="0,1"
+       id="guide19028"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,134,229)" />
+    <sodipodi:guide
+       position="0,2"
+       orientation="0,1"
+       id="guide56176"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,134,229)" />
+    <sodipodi:guide
+       position="0,1"
+       orientation="0,1"
+       id="guide56178"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,134,229)" />
+    <sodipodi:guide
+       position="0,1.9375"
+       orientation="0,1"
+       id="guide56182"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,134,229)" />
+    <sodipodi:guide
+       position="0,1.0625"
+       orientation="0,1"
+       id="guide1789"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,134,229)" />
+    <sodipodi:guide
+       position="0,4"
+       orientation="0,1"
+       id="guide1793"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,134,229)" />
+    <sodipodi:guide
+       position="0,3"
+       orientation="0,1"
+       id="guide1795"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,134,229)" />
+    <sodipodi:guide
+       position="0,7"
+       orientation="0,1"
+       id="guide1797"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,134,229)" />
+    <sodipodi:guide
+       position="0,7.0625"
+       orientation="0,1"
+       id="guide1799"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,134,229)" />
+    <sodipodi:guide
+       position="0,3.9375"
+       orientation="0,1"
+       id="guide1855"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,134,229)" />
+    <sodipodi:guide
+       position="0,3.0625"
+       orientation="0,1"
+       id="guide1859"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,134,229)" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer 2"
+     style="display:inline">
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 8.8894214,2.0625007 V 2.9375009 H 9.458543"
+       id="path995" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 9.7315048,2.9375009 9.7315017,2.0625 10.044627,2.9375 c 0.104312,-0.2916664 0.208816,-0.5833329 0.313128,-0.8749993 v 0.8750002"
+       id="path1027"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 10.671712,2.9375009 V 2.0625007 l 0.5625,0.8750002 V 2.0625007"
+       id="path1075" />
+    <g
+       id="g16207"
+       style="stroke:#000000;stroke-width:0.125;stroke-dasharray:none">
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 0.11861897,2.9375 0.4545,2.0625 0.79038103,2.9375"
+         id="path693"
+         sodipodi:nodetypes="ccc" />
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 0.18415723,2.766767 H 0.72484277"
+         id="path1250"
+         sodipodi:nodetypes="cc" />
+    </g>
+    <g
+       id="g16212"
+       style="stroke:#000000;stroke-width:0.125;stroke-dasharray:none">
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 1.06671,2.0625 v 0.875"
+         id="path3687"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 1.0667103,2.9375009 H 1.359458 c 0.3575692,-9e-7 0.3415059,-0.4797331 0.012,-0.4797331 H 1.0667103"
+         id="path6040"
+         sodipodi:nodetypes="cccc" />
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 1.06671,2.0625 0.3272481,7e-7 c 0.2913521,6e-7 0.2913107,0.3960398 0,0.3960398"
+         id="path6042"
+         sodipodi:nodetypes="csc" />
+    </g>
+    <g
+       id="g16216"
+       style="stroke:#000000;stroke-width:0.125;stroke-dasharray:none">
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 4.12734,2.0625 -0.5532789,7e-7 v 0.8750002 h 0.5592702"
+         id="path423"
+         sodipodi:nodetypes="cccc" />
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 3.5740623,2.4430208 h 0.421279"
+         id="path425" />
+    </g>
+    <g
+       id="g16220"
+       style="stroke:#000000;stroke-width:0.125;stroke-dasharray:none">
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 4.9605789,2.0624993 4.4073,2.0625 v 0.8750002"
+         id="path423-2"
+         sodipodi:nodetypes="ccc" />
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 4.4073012,2.4430201 h 0.421279"
+         id="path425-1" />
+    </g>
+    <path
+       id="path6165"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="m 2.4516494,2.8094757 c -0.056147,0.08162 -0.1398983,0.1280252 -0.2232313,0.1280252 -0.2376769,0 -0.3394981,-0.2815017 -0.3394981,-0.4375002 0,-0.2078782 0.1384522,-0.4375001 0.3394981,-0.4375001 0.094401,0 0.1607082,0.045571 0.2209295,0.1237838"
+       sodipodi:nodetypes="csssc" />
+    <path
+       id="path6165-7"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 5.7301776,2.1862837 C 5.6699563,2.1080709 5.6036491,2.0624999 5.5092481,2.0624999 5.3082022,2.0624999 5.16975,2.2921218 5.16975,2.5 c 0,0.1559985 0.1018212,0.4375002 0.3394981,0.4375002 0.060321,0 0.2210019,-0.025297 0.2210019,-0.2254842 V 2.49402 H 5.53726"
+       sodipodi:nodetypes="csssccc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="m 2.72888,2.0625 9e-7,0.8750009 h 0.2274964 c 0.4368529,0 0.4407515,-0.8749988 0,-0.8750002 L 2.72888,2.0625"
+       id="path6199"
+       sodipodi:nodetypes="ccssc" />
+    <g
+       id="g16225"
+       style="stroke:#000000;stroke-width:0.125;stroke-dasharray:none">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 6.0287139,2.0625007 V 2.9375009"
+         id="path795" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 6.6032141,2.0625007 V 2.9375009"
+         id="path797" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 6.0287158,2.4435168 H 6.6032162"
+         id="path799" />
+    </g>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="m 6.907421,2.0651048 7.5e-4,0.8723961"
+       id="path803" />
+    <path
+       id="path877"
+       style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="m 7.1786277,2.6158848 v 0.027132 c 0,0.105572 0.056322,0.2031246 0.14775,0.2559106 0.091428,0.052786 0.2040721,0.052786 0.2955001,0 0.091428,-0.052786 0.1477501,-0.1503386 0.1477501,-0.2559106 L 7.7696258,2.0625"
+       sodipodi:nodetypes="csssc" />
+    <path
+       id="path877-4"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 16.488837,2.0625 V 2.6430168 C 16.488699,2.8222665 16.614038,2.9375 16.772415,2.9375 c 0.158377,0 0.283501,-0.1159912 0.283502,-0.2944832 l -2e-6,-0.5805168"
+       sodipodi:nodetypes="cczcc" />
+    <g
+       id="g16230"
+       style="stroke:#000000;stroke-width:0.125;stroke-dasharray:none">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 8.0798372,2.0625007 V 2.9375009"
+         id="path977" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 8.5340954,2.0625007 8.0798398,2.5187936"
+         id="path979" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 8.6121682,2.9375009 8.2901753,2.3075148"
+         id="path981" />
+    </g>
+    <path
+       id="path1239-1-1"
+       style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 11.818166,2.9375 C 11.707422,2.9372636 11.530423,2.8541659 11.530423,2.5 c 0,-0.3541659 0.176999,-0.4372636 0.287743,-0.4375 0.110744,2.364e-4 0.287743,0.083334 0.287743,0.4375 0,0.3541659 -0.176999,0.4372636 -0.287743,0.4375 z"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path1239-1-1-2"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 8.2229745,4.9375 C 8.1122305,4.9372636 7.9352315,4.854166 7.9352315,4.5 c 0,-0.3541659 0.176999,-0.4372636 0.287743,-0.4375 0.110744,2.364e-4 0.287743,0.083334 0.287743,0.4375 0,0.3541659 -0.176999,0.4372636 -0.287743,0.4375 z"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 12.400629,2.9375009 V 2.0625007 c 0,0 0.188255,-5e-7 0.2775,-8e-7 0.08925,-3e-7 0.245751,0.047444 0.245751,0.2257574 0,0.178313 -0.148829,0.2257585 -0.240936,0.2257587 -0.09211,2e-7 -0.282315,8e-7 -0.282315,8e-7"
+       id="path1594"
+       sodipodi:nodetypes="cczzzc" />
+    <g
+       id="g16234"
+       style="stroke:#000000;stroke-width:0.125;stroke-dasharray:none">
+      <path
+         id="path1239-1-1-3"
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 13.479583,2.9375 C 13.368839,2.9372636 13.19184,2.854166 13.19184,2.5 c 0,-0.3541659 0.176999,-0.4372636 0.287743,-0.4375 0.110744,2.364e-4 0.287743,0.083334 0.287743,0.4375 0,0.3541659 -0.176999,0.4372636 -0.287743,0.4375 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 13.769485,2.9375009 13.583433,2.7448417"
+         id="path1685"
+         sodipodi:nodetypes="cc" />
+    </g>
+    <g
+       id="g16238"
+       style="stroke:#000000;stroke-width:0.125;stroke-dasharray:none">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 14.069544,2.9375002 V 2.0625 c 0,0 0.188255,-5e-7 0.2775,-8e-7 0.08925,-3e-7 0.245751,0.047444 0.245751,0.2257574 0,0.178313 -0.148829,0.2257585 -0.240936,0.2257587 -0.09211,2e-7 -0.282315,8e-7 -0.282315,8e-7"
+         id="path1594-5"
+         sodipodi:nodetypes="cczzzc" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 14.598632,2.9375009 14.293523,2.5140168"
+         id="path1876" />
+    </g>
+    <path
+       style="font-weight:500;font-size:1.5px;line-height:1.25;font-family:'Gordon URW';-inkscape-font-specification:'Gordon URW Medium';letter-spacing:0.0364583px;display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 14.859618,2.7090935 C 14.843589,2.8335847 14.940646,2.9375 15.081748,2.9375 h 0.09369 c 0.16241,0 0.23848,-0.1202538 0.23848,-0.2029828 0,-0.1255358 -0.05918,-0.2139206 -0.190323,-0.2410866 L 15.061442,2.4604396 C 14.964964,2.4408112 14.883,2.3799049 14.883,2.26352 c 0,-0.1104462 0.09495,-0.20102 0.19875,-0.20102 h 0.09369 c 0.08581,0 0.184285,0.04961 0.208182,0.1761349"
+       id="path2698"
+       sodipodi:nodetypes="ccssccsssc" />
+    <g
+       id="g16242"
+       style="stroke:#000000;stroke-width:0.125;stroke-dasharray:none">
+      <path
+         style="font-weight:500;font-size:1.5px;line-height:1.25;font-family:'Gordon URW';-inkscape-font-specification:'Gordon URW Medium';letter-spacing:0.0364583px;display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 15.644211,2.0625007 h 0.568005"
+         id="path2734" />
+      <path
+         style="font-weight:500;font-size:1.5px;line-height:1.25;font-family:'Gordon URW';-inkscape-font-specification:'Gordon URW Medium';letter-spacing:0.0364583px;display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 15.928213,2.0625014 15.928963,2.9375"
+         id="path2736"
+         sodipodi:nodetypes="cc" />
+    </g>
+    <path
+       id="path2903-4"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 17.863013,2.0624998 17.603826,2.9375 l -0.0067,5e-7 -0.0067,4e-7 -0.259187,-0.8750002"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path4240-5-6"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="m 18.140582,2.0624998 0.247503,0.8750007 0.2475,-0.8749892 0.247494,0.8749998 0.247497,-0.8750113"
+       sodipodi:nodetypes="ccccc" />
+    <g
+       id="g16246"
+       style="stroke:#000000;stroke-width:0.125;stroke-dasharray:none">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 19.924865,2.0625007 19.409451,2.9375009"
+         id="path15449" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 19.470426,2.0625007 0.516946,0.8750002"
+         id="path15451" />
+    </g>
+    <g
+       id="g16250"
+       style="stroke:#000000;stroke-width:0.125;stroke-dasharray:none">
+      <path
+         id="path15465-2"
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 20.2326,2.0624999 0.281904,0.5257443 0.281905,-0.5257435"
+         sodipodi:nodetypes="ccc" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 20.514508,2.5882395 V 2.9375009"
+         id="path15490" />
+    </g>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="m 21.550457,2.9375009 h -0.48399 l 0.475086,-0.8750002 h -0.464576"
+       id="path15500" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 8.9605616,0.28124935 V 0.93749952 H 9.3874028"
+       id="path995-4" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="m 9.8097857,0.93750312 -2.3e-6,-0.65625067 0.2348436,0.65624997 c 0.07823,-0.2187498 0.156612,-0.43749964 0.234846,-0.65624944 v 0.65625014"
+       id="path1027-8"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 10.742024,0.93749952 V 0.28124935 l 0.421875,0.65625017 V 0.28124935"
+       id="path1075-5" />
+    <g
+       id="g16207-3"
+       style="display:inline;stroke-width:0.16666667;stroke-dasharray:none;stroke:#000000"
+       transform="matrix(0.75,0,0,0.75,0.113625,-1.265625)">
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.16666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 0.11861897,2.9375 0.4545,2.0625 0.79038103,2.9375"
+         id="path693-0"
+         sodipodi:nodetypes="ccc" />
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.16666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 0.18415723,2.766767 H 0.72484277"
+         id="path1250-9"
+         sodipodi:nodetypes="cc" />
+    </g>
+    <g
+       id="g16212-4"
+       style="display:inline;stroke-width:0.16666667;stroke-dasharray:none;stroke:#000000"
+       transform="matrix(0.75,0,0,0.75,0.33622792,-1.2656263)">
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.16666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 1.06671,2.0625 v 0.875"
+         id="path3687-5"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.16666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 1.0667103,2.9375009 H 1.359458 c 0.3575692,-9e-7 0.3415059,-0.4797331 0.012,-0.4797331 H 1.0667103"
+         id="path6040-2"
+         sodipodi:nodetypes="cccc" />
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.16666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 1.06671,2.0625 0.3272481,7e-7 c 0.2913521,6e-7 0.2913107,0.3960398 0,0.3960398"
+         id="path6042-5"
+         sodipodi:nodetypes="csc" />
+    </g>
+    <g
+       id="g16216-7"
+       style="display:inline;stroke-width:0.16666667;stroke-dasharray:none;stroke:#000000"
+       transform="matrix(0.75,0,0,0.75,0.96342405,-1.2656263)">
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.16666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 4.12734,2.0625 -0.5532789,7e-7 v 0.8750002 h 0.5592702"
+         id="path423-1"
+         sodipodi:nodetypes="cccc" />
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.16666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 3.5740623,2.4430208 h 0.421279"
+         id="path425-2" />
+    </g>
+    <g
+       id="g16220-8"
+       style="display:inline;stroke-width:0.16666667;stroke-dasharray:none;stroke:#000000"
+       transform="matrix(0.75,0,0,0.75,1.1709849,-1.2656264)">
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.16666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 4.9605789,2.0624993 4.4073,2.0625 v 0.8750002"
+         id="path423-2-2"
+         sodipodi:nodetypes="ccc" />
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.16666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 4.4073012,2.4430201 h 0.421279"
+         id="path425-1-3" />
+    </g>
+    <path
+       id="path6165-8"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="m 2.3813082,0.84148062 c -0.04211,0.061215 -0.1049237,0.096019 -0.1674234,0.096019 -0.1782577,0 -0.2546236,-0.2111263 -0.2546236,-0.32812518 0,-0.15590865 0.1038391,-0.32812507 0.2546236,-0.32812507 0.070801,0 0.1205311,0.0341782 0.1656971,0.0928378"
+       sodipodi:nodetypes="csssc" />
+    <path
+       id="path6165-7-1"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="m 5.6601332,0.37408642 c -0.045166,-0.0586596 -0.094896,-0.0928378 -0.1656971,-0.0928378 -0.1507845,0 -0.2546236,0.17221642 -0.2546236,0.32812507 0,0.11699888 0.076366,0.32812518 0.2546236,0.32812518 0.045241,0 0.1657514,-0.018973 0.1657514,-0.1691132 V 0.60488864 H 5.515445"
+       sodipodi:nodetypes="csssccc" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="m 2.7984319,0.28124874 7e-7,0.65625068 h 0.1706223 c 0.3276397,0 0.3305636,-0.6562491 0,-0.65625015 l -0.170623,-5.3e-7"
+       id="path6199-8"
+       sodipodi:nodetypes="ccssc" />
+    <g
+       id="g16225-9"
+       style="display:inline;stroke-width:0.16666667;stroke-dasharray:none;stroke:#000000"
+       transform="matrix(0.75,0,0,0.75,1.5789913,-1.2656262)">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.16666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 6.0287139,2.0625007 V 2.9375009"
+         id="path795-8" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.16666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 6.6032141,2.0625007 V 2.9375009"
+         id="path797-1" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.16666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 6.0287158,2.4435168 H 6.6032162"
+         id="path799-8" />
+    </g>
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="m 6.9075147,0.28352794 5.625e-4,0.65429708"
+       id="path803-8" />
+    <path
+       id="path877-2"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="m 7.2525027,0.69640963 v 0.020349 c 0,0.079179 0.042242,0.1523435 0.1108125,0.191933 0.068571,0.039589 0.1530541,0.039589 0.2216251,0 0.068571,-0.039589 0.1108126,-0.112754 0.1108126,-0.191933 l -1.6e-6,-0.43538757"
+       sodipodi:nodetypes="csssc" />
+    <path
+       id="path877-4-5"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="m 16.559722,0.28124863 v 0.43538759 c -1.04e-4,0.1344373 0.0939,0.2208624 0.212683,0.2208624 0.118783,0 0.212626,-0.086993 0.212627,-0.2208624 l -2e-6,-0.43538759"
+       sodipodi:nodetypes="cczcc" />
+    <g
+       id="g16230-5"
+       style="display:inline;stroke-width:0.16666667;stroke-dasharray:none;stroke:#000000"
+       transform="matrix(0.75,0,0,0.75,2.0865007,-1.2656262)">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.16666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 8.0798372,2.0625007 V 2.9375009"
+         id="path977-6" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.16666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 8.5340954,2.0625007 8.0798398,2.5187936"
+         id="path979-0" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.16666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 8.6121682,2.9375009 8.2901753,2.3075148"
+         id="path981-0" />
+    </g>
+    <path
+       id="path1239-1-1-9"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="m 11.818166,0.93749862 c -0.08306,-1.773e-4 -0.215807,-0.062501 -0.215807,-0.32812499 0,-0.26562443 0.132749,-0.3279477 0.215807,-0.328125 0.08306,1.773e-4 0.215807,0.0625005 0.215807,0.328125 0,0.26562439 -0.132749,0.32794769 -0.215807,0.32812499 z"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 12.466035,0.93749942 V 0.28124925 c 0,0 0.141192,-3.7e-7 0.208125,-6e-7 0.06694,-2.2e-7 0.184314,0.035583 0.184314,0.16931805 0,0.13373475 -0.111622,0.16931888 -0.180702,0.16931903 -0.06908,1.5e-7 -0.211737,6e-7 -0.211737,6e-7"
+       id="path1594-6"
+       sodipodi:nodetypes="cczzzc" />
+    <g
+       id="g16234-5"
+       style="display:inline;stroke-width:0.16666667;stroke-dasharray:none;stroke:#000000"
+       transform="matrix(0.75,0,0,0.75,3.3701656,-1.2656263)">
+      <path
+         id="path1239-1-1-3-7"
+         style="fill:none;stroke:#000000;stroke-width:0.16666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 13.479583,2.9375 C 13.368839,2.9372636 13.19184,2.854166 13.19184,2.5 c 0,-0.3541659 0.176999,-0.4372636 0.287743,-0.4375 0.110744,2.364e-4 0.287743,0.083334 0.287743,0.4375 0,0.3541659 -0.176999,0.4372636 -0.287743,0.4375 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.16666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 13.769485,2.9375009 13.583433,2.7448417"
+         id="path1685-7"
+         sodipodi:nodetypes="cc" />
+    </g>
+    <g
+       id="g16238-9"
+       style="display:inline;stroke-width:0.16666667;stroke-dasharray:none;stroke:#000000"
+       transform="matrix(0.75,0,0,0.75,3.583522,-1.2656264)">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.16666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 14.069544,2.9375002 V 2.0625 c 0,0 0.188255,-5e-7 0.2775,-8e-7 0.08925,-3e-7 0.245751,0.047444 0.245751,0.2257574 0,0.178313 -0.148829,0.2257585 -0.240936,0.2257587 -0.09211,2e-7 -0.282315,8e-7 -0.282315,8e-7"
+         id="path1594-5-5"
+         sodipodi:nodetypes="cczzzc" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.16666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 14.598632,2.9375009 14.293523,2.5140168"
+         id="path1876-2" />
+    </g>
+    <path
+       style="font-weight:500;font-size:1.5px;line-height:1.25;font-family:'Gordon URW';-inkscape-font-specification:'Gordon URW Medium';letter-spacing:0.0364583px;display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="m 14.928704,0.76619372 c -0.01202,0.093368 0.06077,0.1713049 0.166598,0.1713049 h 0.07027 c 0.121808,0 0.17886,-0.09019 0.17886,-0.1522371 0,-0.0941518 -0.04439,-0.16044044 -0.142742,-0.18081494 l -0.121615,-0.0247432 c -0.07236,-0.0147213 -0.133831,-0.060401 -0.133831,-0.1476897 0,-0.0828347 0.07121,-0.150765 0.149062,-0.150765 h 0.07027 c 0.06436,0 0.138213,0.0372075 0.156136,0.13210117"
+       id="path2698-0"
+       sodipodi:nodetypes="ccssccsssc" />
+    <g
+       id="g16242-1"
+       style="display:inline;stroke-width:0.16666667;stroke-dasharray:none;stroke:#000000"
+       transform="matrix(0.75,0,0,0.75,3.9820534,-1.2656263)">
+      <path
+         style="font-weight:500;font-size:1.5px;line-height:1.25;font-family:'Gordon URW';-inkscape-font-specification:'Gordon URW Medium';letter-spacing:0.0364583px;display:inline;fill:none;stroke:#000000;stroke-width:0.16666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 15.644211,2.0625007 h 0.568005"
+         id="path2734-6" />
+      <path
+         style="font-weight:500;font-size:1.5px;line-height:1.25;font-family:'Gordon URW';-inkscape-font-specification:'Gordon URW Medium';letter-spacing:0.0364583px;display:inline;fill:none;stroke:#000000;stroke-width:0.16666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 15.928213,2.0625014 15.928963,2.9375"
+         id="path2736-7"
+         sodipodi:nodetypes="cc" />
+    </g>
+    <path
+       id="path2903-4-4"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="m 17.796541,0.28124857 -0.19439,0.65625015 -0.005,4e-7 -0.005,3e-7 -0.19439,-0.65625018"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path4240-5-6-1"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="m 18.264331,0.28124775 0.185627,0.65625057 0.185625,-0.65624194 0.185621,0.65624984 0.185623,-0.65625847"
+       sodipodi:nodetypes="ccccc" />
+    <g
+       id="g16246-3"
+       style="display:inline;stroke-width:0.16666667;stroke-dasharray:none;stroke:#000000"
+       transform="matrix(0.75,0,0,0.75,4.9246029,-1.2656262)">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.16666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 19.924865,2.0625007 19.409451,2.9375009"
+         id="path15449-3" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.16666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 19.470426,2.0625007 0.516946,0.8750002"
+         id="path15451-9" />
+    </g>
+    <g
+       id="g16250-9"
+       style="display:inline;stroke-width:0.16666667;stroke-dasharray:none;stroke:#000000"
+       transform="matrix(0.75,0,0,0.75,5.1286261,-1.2656263)">
+      <path
+         id="path15465-2-5"
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.16666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 20.2326,2.0624999 0.281904,0.5257443 0.281905,-0.5257435"
+         sodipodi:nodetypes="ccc" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.16666667;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 20.514508,2.5882395 V 2.9375009"
+         id="path15490-9" />
+    </g>
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 21.489959,0.93749952 H 21.126966 L 21.483281,0.28124935 H 21.134849"
+       id="path15500-4" />
+    <g
+       id="g16723"
+       style="stroke:#000000;stroke-width:0.125;stroke-dasharray:none">
+      <path
+         id="path16578-9"
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 6.6820295,4.2770001 c 0,0.1065096 -0.066144,0.21075 -0.2329687,0.2107506 -0.1668248,7e-7 -0.2329688,-0.1042397 -0.2329688,-0.2107493 0,-0.1065096 0.081273,-0.2145001 0.2329688,-0.2145008 0.1516953,-6e-7 0.2329687,0.1079899 0.2329687,0.2144995 z"
+         sodipodi:nodetypes="scscs" />
+      <path
+         id="path16584-0"
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 6.7030595,4.7060015 c 0,0.1304792 -0.099211,0.2315001 -0.2539987,0.2315001 -0.154788,0 -0.2539988,-0.1010209 -0.2539988,-0.2315001 0,-0.1181094 0.079728,-0.2182487 0.2539988,-0.2182487 0.1742707,0 0.2539987,0.1001393 0.2539987,0.2182487 z"
+         sodipodi:nodetypes="scscs" />
+    </g>
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 2.8376341,4.0625013 2.5892355,4.7562515 H 3.213831"
+       id="path15998" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 3.0354811,4.4595014 V 4.9375016"
+       id="path16000" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 0.24110768,4.0625013 V 4.9375016"
+       id="path15808" />
+    <path
+       id="path15915"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="m 0.91626083,4.2970205 c -0.008821,-0.096839 0.0467839,-0.1880031 0.13677347,-0.2242392 0.08999,-0.036236 0.1930283,-0.00895 0.2534459,0.06711 0.060417,0.076063 0.063889,0.1828705 0.00854,0.2627171 -0.022548,0.032529 -0.053123,0.054735 -0.088961,0.075523 -0.040758,0.023643 -0.081119,0.048119 -0.1171089,0.078581 C 0.99477328,4.6533535 0.92081283,4.7891585 0.90156992,4.9375012 L 1.35428,4.9375"
+       sodipodi:nodetypes="csssssc" />
+    <path
+       id="path15940"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="m 1.8008106,4.0625013 h 0.4179601 v 0.00914 L 1.9093064,4.3811059 c 0.080492,-0.02957 0.1699896,-0.021598 0.2439883,0.021732 0.1113368,0.065194 0.1654848,0.1966702 0.1323528,0.3213636 C 2.2525155,4.8488951 2.1402483,4.9361532 2.0112351,4.9374847 1.8822219,4.9388163 1.7681776,4.853894 1.732479,4.729911"
+       sodipodi:nodetypes="ccccsssc" />
+    <path
+       id="path16187"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 3.9375013,4.0625013 H 3.5766886 l 3.6e-6,0.3878284 c 0.060775,-0.049535 0.1399453,-0.071283 0.2178627,-0.059846 0.1223203,0.017955 0.2179699,0.11356 0.2347686,0.2346602 C 4.0461225,4.7462441 3.9800375,4.8637696 3.8671208,4.913606 3.7542042,4.963442 3.6215608,4.933627 3.5415524,4.840425"
+       sodipodi:nodetypes="cccsssc" />
+    <g
+       id="g16719"
+       style="stroke:#000000;stroke-width:0.125;stroke-dasharray:none">
+      <circle
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         id="path16322"
+         cx="4.6751461"
+         cy="4.6480017"
+         r="0.28950009" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 4.8066037,4.0625013 4.6899584,4.1353893 C 4.5535699,4.2206142 4.3856475,4.3803434 4.3856475,4.6483278"
+         id="path16364"
+         sodipodi:nodetypes="csc" />
+    </g>
+    <g
+       id="g16719-6"
+       style="display:inline;stroke:#000000;stroke-width:0.125;stroke-dasharray:none"
+       transform="rotate(180,6.0059522,4.5000015)">
+      <circle
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         id="path16322-9"
+         cx="4.6751461"
+         cy="4.6480017"
+         r="0.28950009" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 4.8038843,4.0625013 4.6890951,4.1362944 C 4.5141375,4.2487671 4.3856475,4.4005257 4.3856475,4.6483278"
+         id="path16364-0"
+         sodipodi:nodetypes="csc" />
+    </g>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 5.3441017,4.0625013 H 5.7837832 L 5.49762,4.9375016"
+       id="path16554" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 9.347433,4.1745013 8.8030621,4.5000014 9.347433,4.8255015"
+       id="path16997" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 9.6243505,4.1745013 10.168722,4.5000014 9.6243505,4.8255015"
+       id="path16997-2" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       id="path17021"
+       sodipodi:type="arc"
+       sodipodi:cx="10.248337"
+       sodipodi:cy="4.859374"
+       sodipodi:rx="0.59467399"
+       sodipodi:ry="0.59467399"
+       sodipodi:start="0.123615"
+       sodipodi:end="0.50832227"
+       sodipodi:open="true"
+       sodipodi:arc-type="arc"
+       d="m 10.838473,4.9326976 a 0.59467399,0.59467399 0 0 1 -0.07065,0.2161116" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="m 10.444546,4.9400016 v -0.0025"
+       id="path17031" />
+    <g
+       id="g18094"
+       transform="translate(-9.7213646,1.9999984)"
+       style="stroke:#000000;stroke-width:0.125;stroke-dasharray:none">
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 21.509136,4.9400016 v -0.0025"
+         id="path17031-4" />
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 21.509136,4.50125 V 4.49875"
+         id="path17031-4-4" />
+    </g>
+    <g
+       id="g18090"
+       transform="translate(-9.7213646,1.9999984)"
+       style="stroke:#000000;stroke-width:0.125;stroke-dasharray:none">
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         id="path17021-3"
+         sodipodi:type="arc"
+         sodipodi:cx="20.641045"
+         sodipodi:cy="4.859374"
+         sodipodi:rx="0.59467399"
+         sodipodi:ry="0.59467399"
+         sodipodi:start="0.123615"
+         sodipodi:end="0.50832227"
+         sodipodi:open="true"
+         sodipodi:arc-type="arc"
+         d="m 21.231181,4.9326976 a 0.59467399,0.59467399 0 0 1 -0.07065,0.2161116" />
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 21.23118,4.5 V 4.4975"
+         id="path17031-4-4-0" />
+    </g>
+    <g
+       id="g1863"
+       transform="translate(-1.2388847)"
+       style="stroke:#000000;stroke-width:0.125;stroke-dasharray:none">
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 12.652388,4.0625013 V 4.74099"
+         id="path15808-5"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 12.652388,4.9400016 v -0.0025"
+         id="path17031-3" />
+    </g>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 12.594499,6.9375016 13.168495,5.989"
+       id="path17041"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 14.331121,6.9375016 13.757125,5.989"
+       id="path17041-3"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       id="path17049"
+       sodipodi:type="arc"
+       sodipodi:cx="8.0815248"
+       sodipodi:cy="6.4885159"
+       sodipodi:rx="1.3125"
+       sodipodi:ry="1.3125"
+       sodipodi:start="2.7705572"
+       sodipodi:end="3.5250687"
+       sodipodi:open="true"
+       sodipodi:arc-type="arc"
+       d="m 6.8583373,6.9644029 a 1.3125,1.3125 0 0 1 0.00601,-0.9669541" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       id="path17049-3"
+       sodipodi:type="arc"
+       sodipodi:cx="-5.9259892"
+       sodipodi:cy="6.4885159"
+       sodipodi:rx="1.3125"
+       sodipodi:ry="1.3125"
+       sodipodi:start="2.7705572"
+       sodipodi:end="3.5250687"
+       sodipodi:open="true"
+       sodipodi:arc-type="arc"
+       d="m -7.1491767,6.9644029 a 1.3125,1.3125 0 0 1 0.00601,-0.9669541"
+       transform="scale(-1,1)" />
+    <g
+       id="g17713"
+       transform="translate(-0.02257812)"
+       style="stroke:#000000;stroke-width:0.125;stroke-dasharray:none">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 12.999467,4.3182514 h 0.688127"
+         id="path17701" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 12.937539,4.6565015 h 0.688128"
+         id="path17703" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 13.223601,4.0335013 13.056785,4.9375016"
+         id="path17705" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 13.568382,4.0335013 13.402875,4.9375016"
+         id="path17707" />
+    </g>
+    <g
+       id="g17814"
+       transform="translate(0.1462545)"
+       style="stroke:#000000;stroke-width:0.125;stroke-dasharray:none">
+      <path
+         style="font-weight:500;font-size:1.5px;line-height:1.25;font-family:'Gordon URW';-inkscape-font-specification:'Gordon URW Medium';letter-spacing:0.0364583px;display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 14.055268,4.6616379 c -0.01243,0.096535 0.06283,0.1771138 0.172247,0.1771138 h 0.07265 c 0.125938,0 0.184925,-0.093249 0.184925,-0.1573995 0,-0.097345 -0.04589,-0.1658809 -0.147582,-0.1869463 l -0.125739,-0.025582 c -0.07481,-0.01522 -0.13837,-0.06245 -0.13837,-0.1526979 0,-0.085643 0.07363,-0.1558774 0.154117,-0.1558774 h 0.07265 c 0.06654,0 0.1429,0.038469 0.161431,0.1365807"
+         id="path2698-2"
+         sodipodi:nodetypes="ccssccsssc" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 14.26731,4.9375016 V 4.8387535"
+         id="path17807" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 14.26731,4.0625013 v 0.097749"
+         id="path17809" />
+    </g>
+    <g
+       id="g17949"
+       transform="translate(0.31060114)"
+       style="stroke:#000000;stroke-width:0.125;stroke-dasharray:none">
+      <ellipse
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         id="path17816"
+         cx="15.843939"
+         cy="-3.6803589"
+         rx="0.14294097"
+         ry="0.21938865"
+         transform="rotate(30)" />
+      <ellipse
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         id="path17816-2"
+         cx="15.127377"
+         cy="-3.8324718"
+         rx="0.14294097"
+         ry="0.21938865"
+         transform="rotate(30)" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 15.587597,3.9767482 15.019867,4.960085"
+         id="path17848"
+         sodipodi:nodetypes="cc" />
+    </g>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 17.153939,4.9375 C 17.013222,4.4628246 16.59788,4.5 16.59788,4.2693483 c 0,-0.1474127 0.126769,-0.2068483 0.226492,-0.2068483 0.09972,0 0.193798,0.069012 0.193798,0.190431 0,0.224284 -0.472882,0.1647436 -0.472882,0.4284282 0,0.182252 0.117022,0.2561424 0.254576,0.2561424 0.180366,0 0.254388,-0.1687978 0.409067,-0.254424"
+       id="path17850"
+       sodipodi:nodetypes="csssssc" />
+    <g
+       id="g17944"
+       transform="translate(0.64682572)"
+       style="stroke:#000000;stroke-width:0.125;stroke-dasharray:none">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 17.103686,4.2750014 V 4.6480015"
+         id="path17866" />
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 16.942172,4.3682514 17.2652,4.5547515"
+         id="path17866-2" />
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 16.942172,4.5547517 17.2652,4.3682512"
+         id="path17866-6" />
+    </g>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="m 18.41951,4.5000014 h 0.432981"
+       id="path17907" />
+    <g
+       id="g17939"
+       transform="translate(1.0039088)"
+       style="stroke:#000000;stroke-width:0.125;stroke-dasharray:none">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 18.255356,4.3484734 h 0.718"
+         id="path17933" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 18.255356,4.7791326 h 0.718"
+         id="path17935" />
+    </g>
+    <g
+       id="g17983"
+       transform="translate(1.2521179)"
+       style="stroke:#000000;stroke-width:0.125;stroke-dasharray:none">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 19.617561,4.9375016 V 4.2045013"
+         id="path17977" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 19.250317,4.5725015 h 0.736"
+         id="path17979" />
+    </g>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 7.9445361,5.9509997 H 7.7677054 V 6.9375 h 0.1768307"
+       id="path17993" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="m 8.2185521,5.9509997 h 0.176831 V 6.9375 h -0.176831"
+       id="path17993-4" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="m 12.061519,5.8138017 0.126952,0.1371967"
+       id="path18096"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 3.7242256,5.82995 V 7.0572594"
+       id="path64860"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 4.5835346,7.1500023 H 5.383535"
+       id="path71230" />
+    <path
+       id="path96752-5"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="m 11.105889,6.4151851 c 0,0.1199249 -0.144193,0.1317888 -0.28496,0.050516 -0.140767,-0.081272 -0.28496,-0.066741 -0.28496,0.050189"
+       sodipodi:nodetypes="czc" />
+    <path
+       id="path102685-7"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 5.7479816,6.3885241 6.0200297,6.000001 6.2920778,6.388526"
+       sodipodi:nodetypes="ccc" />
+    <path
+       id="path17993-8-3"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="m 9.3051395,6.9374999 c -0.109406,0 -0.176831,-0.075034 -0.176831,-0.1792086 0,-0.2293408 -0.03781,-0.275525 -0.130208,-0.3140415 0.0924,-0.038517 0.130208,-0.084701 0.130208,-0.3140415 0,-0.1041746 0.06743,-0.1792086 0.176831,-0.1792086"
+       sodipodi:nodetypes="cscsc" />
+    <path
+       id="path17993-8-3-5"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="m 9.6665475,6.9374999 c 0.109406,0 0.176831,-0.075034 0.176831,-0.1792086 0,-0.2293408 0.03781,-0.275525 0.130208,-0.3140415 -0.0924,-0.038517 -0.130208,-0.084701 -0.130208,-0.3140415 0,-0.1041746 -0.06743,-0.1792086 -0.176831,-0.1792086"
+       sodipodi:nodetypes="cscsc" />
+    <g
+       id="g56774"
+       style="display:inline;stroke:#000000;stroke-width:0.125;stroke-dasharray:none"
+       transform="translate(10.87143,-2)">
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 1.3359375,6.9375 V 6.935"
+         id="path17031-6" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="m 1.0613906,6.2501762 c 0.027886,-0.1092298 0.1179588,-0.2059373 0.2652728,-0.2059373 0.1473139,0 0.243512,0.1065196 0.243512,0.2536032 0,0.1985161 -0.2342379,0.2067173 -0.2342379,0.3636183"
+         id="path56382"
+         sodipodi:nodetypes="cssc" />
+    </g>
+    <g
+       id="g105204"
+       style="display:inline;stroke:#000000;stroke-width:0.125;stroke-dasharray:none"
+       transform="translate(-1.6693934)">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 2.2376309,6.0000019 V 6.3606791"
+         id="path58659" />
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 2.4459642,6.0000019 V 6.3606791"
+         id="path58659-7" />
+    </g>
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="M 1.41678,6.0000019 V 6.3606791"
+       id="path58659-7-0" />
+    <g
+       id="g61784"
+       style="display:inline;stroke-width:0.125;stroke-dasharray:none;stroke:#000000"
+       transform="translate(-4.6584918)">
+      <path
+         id="path61774"
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         transform="rotate(15)"
+         d="m 8.7429784,4.4354985 c 0.011905,0.1609194 -0.09174,0.2464085 -0.208067,0.2464085 -0.106675,0 -0.1983967,-0.096472 -0.1983967,-0.2458075 0,-0.1428837 0.105204,-0.2349711 0.1933989,-0.2479528 0.094894,-0.013968 0.1965639,0.024302 0.2130648,0.2473518 z"
+         sodipodi:nodetypes="sssss" />
+      <path
+         id="path61778"
+         style="fill:none;stroke:#000000;stroke-width:0.125;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+         d="M 7.4841727,6.8641729 C 7.313674,6.9942381 7.0425928,7.000634 6.8639329,6.8773505 6.6852729,6.7540669 6.6193369,6.5204921 6.6880925,6.3155837 6.7615135,6.0967712 6.9745738,5.9785995 7.1915559,5.9949361 7.4462124,6.0141091 7.6283127,6.2008477 7.6011605,6.4377229 7.567296,6.7331559 7.2469057,6.8111048 7.2669271,6.7057292 7.3128543,6.4640072 7.3532239,6.2527974 7.3532239,6.2527974"
+         sodipodi:nodetypes="csssssc" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
# Description

Add SVG file containing single-line characters to be used for text on engraved panels. The characters are similar to those found in Gordon Medium, but are strictly of uniform stroke width. Character size and stroke width can be varied independently. All ASCII characters provided. 

A proper font will be created once I figure out how to do it.
