### PR TITLE
Updated Sketch Template for Arduino

### DIFF
--- a/software/templates/OHSketchTemplate/OHSketchTemplate.ino
+++ b/software/templates/OHSketchTemplate/OHSketchTemplate.ino
@@ -48,6 +48,9 @@
  *
  *   DCS-BIOS is released under the following terms:
  *   https://github.com/dcs-bios/dcs-bios/blob/develop/DCS-BIOS-License.txt
+ * 
+ *   Use only the following DCS-BIOS Arduino Library
+ *   https://github.com/DCSFlightpanels/dcs-bios-arduino-library
  *
  *   ---------------------------------------------------------------------------------
  *
@@ -58,9 +61,9 @@
 
 /**
  * @file OHSketchTemplate.ino
- * @author Balz Reber
- * @date 29.12.2019
- * @version u.0.0.1 (untested)
+ * @author <full name> @ <email@somehost.com>
+ * @date <dd.mm.yyyy>
+ * @version u.0.0.1
  * @warning This sketch is based on a wiring diagram, and was not yet tested on hardware
  * @brief This is the OpenHornet Sketch Template
  *
@@ -81,9 +84,19 @@
  */
 
 /**
- * Set DCS Bios to use irq serial
+ * Check if we're on a Mega328 or Mega2560 and define the correct
+ * serial interface
+ * 
  */
-#define DCSBIOS_IRQ_SERIAL
+#if defined(__AVR_ATmega328P__) ||  defined(__AVR_ATmega2560__)
+  #define DCSBIOS_IRQ_SERIAL
+#else
+  #define DCSBIOS_DEFAULT_SERIAL
+#endif
+
+#ifdef __AVR__
+ #include <avr/power.h> 
+#endif
 
 /**
  * DCS Bios library include
@@ -151,6 +164,8 @@ void loop() {
 * @returns Description of returned value.
 */
 int sampleFunction(int myParam1, int myParam2) {
-  int myReturn;
+  // Must initialize a return value to avoid compile errors
+  int myReturn = 0;  
+
   return myReturn;
 }


### PR DESCRIPTION
# Description
Updated OHSketchTemplate.ino to check for which Arduino is used as well and point user to correct library to include

Addresses # (issue)
Does not compile on a Pro-Mini as is.
fixed define to include correct serial module in DCS-BIOS based on the processor use
updated same function to avoid compile errors when returning uninitialized value

## Type of change
Updated template 

Please delete options that are not relevant.

- [ ] New MCAD (new Mechanical Model)
- [ ] Change MCAD (fixed issue with existing MCAD model)
- [ ] New ECAD (new PCB)
- [ ] Change ECAD (fixed issue with existing PCB)
- [X] New software module (new software module for slave)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Yes,   function does nothing but will now compile

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware: Pro Micro
* Toolchain: Arduino 
* SDK: 1.8.16
* Compiled using both Arduino IDE and Visual Studio Code + PlatoformIO

# Checklist: (Delete non-relevant sections)

## Software:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
