### PR TITLE
Update MCAD README.md to have a link to the MCAD / F360 tutorial wiki

### DIFF
--- a/MCAD/README.md
+++ b/MCAD/README.md
@@ -9,4 +9,5 @@ The OpenHornet MCAD model has been transitioned to Fusion 360 and will be mainta
 * Right Console (RC): https://a360.co/37pBiWj
 * Center Tub (CT): https://a360.co/3LKM3mc
 
+For more information on how to get started with downloading and importing OpenHornet F360 models, you may also want to check out the [tutorial in our wiki](https://github.com/jrsteensen/OpenHornet/wiki/HOWTO:-Downloading-&-Importing-OpenHornet-F360-Models).
 This file will be updated as necessary as this transition progresses.


### PR DESCRIPTION
# Description

MCAD readme.md now also links to the MCAD tutorial wiki.

Addresses # (issue)

Improves discoverability of the wiki.

## Type of change

Doc update

# How Has This Been Tested?

not relevant

# Checklist: (Delete non-relevant sections)

not relevant
