### PR TITLE
Added a note about using online tools to review schematics.

### DIFF
--- a/ECAD/REVIEW.md
+++ b/ECAD/REVIEW.md
@@ -1,0 +1,8 @@
+Sometimes we might want to take a quick look to schematics directly on github.
+Sadly, Github doesn't natively support kicad file previews. However, there are
+tools which can help with reviewing changes without pulling the changes and opening
+using kicad. For example:
+
+https://kicanvas.org/
+
+This tool works well with schematics but it will fail to open most OpenHornet PCBs due dependencies.


### PR DESCRIPTION
Added a small md file pointing to a tool that can be used to review schematics and some PCBs online without the need to have kicad installed.

# Description

Updated documentation to point to an online tool that can be used to review schematics and some PCBs without installing kicad.
The reason I'm adding this is that I wanted to review recent schematics to see how different they were from the ones I created. However, I'm not allowed to install Kicad at my work computer so I need an online tool.

Addresses # None

## Motivation and Context
see description

## Type of change

Please delete options that are not relevant.
- [X] Docs - New (A new document that is neither MCAD or ECAD)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration:

Opened a few of the schematics on the website. Sadly several of the PCBs will not show.

# Screenshots:
N/A

# Checklist: (Delete non-relevant sections)
N/A
